### PR TITLE
README Link to the trello app directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository will contain example projects using Binaris Functions
 
 Each project will have a separate directory
 
-`trello-auto-updates` - Example project for a trello webhook which updates cards based on list names
+[`trello-auto-updates`](trello-auto-updates) - Example project for a trello webhook which updates cards based on list names


### PR DESCRIPTION
Tested the README on the branch on the github site.

The link is relative, and points at the example in its own branch.