### PR TITLE
create optimal build path

### DIFF
--- a/fractal-terrain-generation/README.md
+++ b/fractal-terrain-generation/README.md
@@ -3,13 +3,13 @@
 Demo originally created for talk given by Ryland Goldstein at _Serverless conf 2018_ in San Francisco.
 
 1. Replace <BINARIS_ACCOUNT_NUMBER> in `dist/index.html` with your account number.
-1. Make sure to export `BINARIS_ACCOUNT_NUMBER` to your environment
-1. Run `npm install`
-1. Run `bn deploy public_fractal`
-1. Export the URL printed by `bn deploy` as `FRACTAL_ENDPOINT`
-   ie `export FRACTAL_ENDPOINT=https://run.binaris.com/v2/run/<YOUR_ACCOUNT_NUMBER>/public_fractal`
+1. Export `BINARIS_ACCOUNT_NUMBER` to your environment
+1. Run the following command
 
-1. Run `npm run start`
+    `export FRACTAL_ENDPOINT=https://run.binaris.com/v2/run/${BINARIS_ACCOUNT_NUMBER}/public_fractal`
+1. Run `npm install`
+1. Run `npm run build`
+1. Run `bn deploy public_fractal`
 1. Navigate to the generated Binaris function URL in your browser
 
 For even faster generation consider upgrading to the Binaris paid tier.

--- a/fractal-terrain-generation/package.json
+++ b/fractal-terrain-generation/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "webpack-dev-server",
-    "build": "webpack --config webpack.prod.config.js && (bn deploy public_fractal)",
+    "build": "webpack --config webpack.prod.config.js",
     "lint": "./node_modules/.bin/eslint -c .eslintrc.js src/ function_lib/"
   },
   "keywords": [],


### PR DESCRIPTION
Clearly this is not a super simple build path. That being said the previous instructions had a lot of room for error.

The complexity is due to the fact that the `public_fractal` function needs to have all the webpacked Javascript when it's deployed. Making things even more complex is that we need the `FRACTAL_ENDPOINT` at webpack build time which we would expect to get from the `bn deploy`.

In the future (not sure timeline) I'll split it into two functions which should help simplify this aspect.