### PR TITLE
remove obsolete link

### DIFF
--- a/quicksearch/README.md
+++ b/quicksearch/README.md
@@ -1,8 +1,6 @@
 # Quicksearch With Functions
 Fetch textual results as you type with function-based quicksearch.
 
-![flow](images/quicksearch.gif)
-
 # What does it do?
 1. Index textual data in Redis by uploading JSON to a function endpoint.
 1. Super-fast search for textual terms by calling a function endpoint.


### PR DESCRIPTION
tested by looking at https://github.com/binaris/functions-examples/blob/de47d6850a3588cad7c1a2a3302ba6bfed012816/quicksearch/README.md and not seeing a broken link